### PR TITLE
fix handlePublicPath and asyncCSS bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,9 @@ UploadPlugin.prototype.apply = function (compiler) {
         // handle async css files
         if (asyncCSS) {
           updateCssLoad(
-            commonChunksWAbs,
+            // All js files need replace
+            // May appear in html , So tplFiles also needs
+            [...tplFiles, ...jsArr],
             getLocal2CdnObj(cssLocal2CdnObj),
             publicPath
           )

--- a/util/util.js
+++ b/util/util.js
@@ -115,7 +115,8 @@ const handlePublicPath = (publicPath) => (content) => {
     if (prefix) {
       result = `${prefix}${result}`
     }
-    if (suffix) {
+    // suffix possibly is offset , assertion type
+    if (suffix && typeof suffix !== 'number') {
       result += suffix
     }
     return result


### PR DESCRIPTION
在 handlePublicPath 内容替换时 ， 对 suffix 的判断存在问题 ， 这里即使匹配不到 regStr 。 也会被传入 offset 。 导致所有资源都被带上了 offset 。 对其加上类型判断 。[MDN](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/replace#%E6%8C%87%E5%AE%9A%E4%B8%80%E4%B8%AA%E5%87%BD%E6%95%B0%E4%BD%9C%E4%B8%BA%E5%8F%82%E6%95%B0)

asyncCSS 的替换列表扩充 。 对所有 JS 文件都进行是否需要 replace 的检查 。 包括有可能被打进 html script 标签中的 JS 。