### PR TITLE
webpack5 chunk RegExp

### DIFF
--- a/util/regexp.js
+++ b/util/regexp.js
@@ -1,4 +1,6 @@
 exports.getPublicPathExp = () => /__webpack_require__\.p\s?=\s?([^;\n]+);?/g
+exports.getV3ScriptRegExp = () =>
+  /__webpack_require__\.p\s\+\s__webpack_require__\.u\((.*)\)/g
 exports.getV2ScriptRegExp = () =>
   /__webpack_require__\.p\s?\+[^\n]*?(chunkId)[^\n]*?\.js['"];?/g
 exports.getScriptRegExp = () =>

--- a/util/util.js
+++ b/util/util.js
@@ -7,6 +7,7 @@ const {
   getCssHrefRegExp,
   getScriptRegExp,
   getV2ScriptRegExp,
+  getV3ScriptRegExp,
 } = require('./regexp')
 const { isDir, isFile, isType } = require('./status')
 const { logErr } = require('./log')
@@ -276,7 +277,11 @@ function gatherChunks(chunks, chunkFileName) {
  */
 function isEntryChunk(js) {
   const content = read(js)
-  return getScriptRegExp().test(content) || getV2ScriptRegExp().test(content)
+  return (
+    getScriptRegExp().test(content) ||
+    getV2ScriptRegExp().test(content) ||
+    getV3ScriptRegExp().test(content)
+  )
 }
 
 /**

--- a/util/worker/updateScriptSrc/index.js
+++ b/util/worker/updateScriptSrc/index.js
@@ -2,6 +2,7 @@ const { workerData, parentPort } = require('worker_threads')
 const {
   getScriptRegExp,
   getV2ScriptRegExp,
+  getV3ScriptRegExp,
   getPublicPathExp,
 } = require('../../regexp')
 const { TYPES } = require('../../types')
@@ -27,10 +28,16 @@ async function updateScriptSrc(file, chunkCdnMap) {
   // update chunkMap
   const isV1ChunkSyntax = getScriptRegExp().test(content)
   const isV2ChunkSyntax = !isV1ChunkSyntax && getV2ScriptRegExp().test(content)
-  if (isV1ChunkSyntax || isV2ChunkSyntax) {
-    let regExp = getV2ScriptRegExp()
-    if (isV1ChunkSyntax && !isV2ChunkSyntax) {
+  const isV3ChunkSyntax =
+    !isV1ChunkSyntax && !isV2ChunkSyntax && getV3ScriptRegExp().test(content)
+  if (isV1ChunkSyntax || isV2ChunkSyntax || isV3ChunkSyntax) {
+    let regExp
+    if (isV1ChunkSyntax) {
       regExp = getScriptRegExp()
+    } else if (isV2ChunkSyntax) {
+      regExp = getV2ScriptRegExp()
+    } else if (isV3ChunkSyntax) {
+      regExp = getV3ScriptRegExp()
     }
     newContent = newContent.replace(regExp, (match, id) => {
       if (!id) {


### PR DESCRIPTION
webpack chunk会生成如下格式在 runtime.js 中
```
var url = __webpack_require__.p + __webpack_require__.u(chunkId);
```
添加 ```getV3ScriptRegExp ``` 用以匹配该模式并替换